### PR TITLE
FrontendConf теперь от 16 000 руб.; опросы

### DIFF
--- a/README.city.md
+++ b/README.city.md
@@ -108,9 +108,9 @@
 
 ## Москва
 
-### [Frontend Conf](http://frontendconf.ru/)
+### [FrontendConf](http://frontendconf.ru/)
 
-31 мая и 1 июня, 14 000 – 27 000 руб.
+31 мая и 1 июня, 16 000 – 27 000 руб.
 
 ## Одесса
 

--- a/README.date.md
+++ b/README.date.md
@@ -165,9 +165,9 @@
 
 27 мая, Пермь
 
-### [Frontend Conf](http://frontendconf.ru/)
+### [FrontendConf](http://frontendconf.ru/)
 
-31 мая и 1 июня, Москва, 14 000 – 27 000 руб.
+31 мая и 1 июня, Москва, 16 000 – 27 000 руб.
 
 ## Июль
 


### PR DESCRIPTION
Билет FrontendConf теперь стоит от 16 тысяч рублей.

В [твиттере у KharkivJS](https://twitter.com/KharkivJS/status/715531654006194176) сейчас опрос относительно платности конференции, а у SPB Frontend [опрос про темы и спикеров](https://ru.surveymonkey.com/r/NL85V7G). Если вы заинтересованы, то не проходите мимо.
