### PR TITLE
MoscowJS 33, TK° Conf; новые доклады

### DIFF
--- a/city.md
+++ b/city.md
@@ -9,6 +9,7 @@
 - **[Москва](#Москва)**
 - [Нижний Новгород](#Нижний-Новгород)
 - [Новосибирск](#Новосибирск)
+- [Ростов-на-Дону](#Ростов-на-Дону)
 - **[Санкт-Петербург](#Санкт-Петербург)**
 - [Тольятти](#Тольятти)
 - [Томск](#Томск)
@@ -53,6 +54,7 @@
   - «React, Relay и GraphQL — вполне себе нормальный компонентный подход», Павел Черторогов
   - «Я и ИоТ», Вадим Макеев (Opera)
   - «Веб-приложения: дробим монолит», Виктор Грищенко
+  - «API Панорам», Кирилл Дмитренко (Яндекс)
 </details>
 
 ## Ижевск
@@ -66,6 +68,7 @@
 
   - «Vue.js», Наталья Коновалова (Центр Высоких Технологий)
   - «Sass colors refactoring», Иван Мартьянов (EPAM Systems)
+  - «Верстальщики не нужны. На самом деле нет», Роман Коробейников (Piano.io)
 </details>
 
 ## Киев
@@ -95,6 +98,7 @@
   - «Creation of native mobile apps with NativeScript and Angular2», Eugene Alayev
   - «Flux is dead. Long live Flux!», Alexey Raspopov
   - «Reflex and offline-first», Denis Yaremov
+  - «Modern functional concepts and JavaScript», Maks Klymyshyn
 </details>
 
 ## Минск
@@ -115,6 +119,19 @@
 
 ## Москва
 
+### [MoscowJS 33](https://moscowjs.timepad.ru/event/363568/)
+
+25 августа
+
+<details>
+  <summary>**Доклады**</summary>
+
+  - «I promise — images will be loaded!», Антон Корзунов (Яндекс)
+  - «Viewport», Вопиловский Константин (KamaGames Studio)
+  - «Регрессионное тестирование компонентов верстки», Кондратенко Павел (Rambler&Co)
+  - «Создание WYSIWYG-редакторов для веба», Егор Яковишен (Setka)
+</details>
+
 ### [HolyJS](http://holyjs.ru/)
 
 11 декабря
@@ -123,8 +140,10 @@
   <summary>**Доклады**</summary>
 
   - «Build Cross-Platform Desktop Apps with Electron», Feross Aboukhadijeh
+  - «ECMAScript: latest and upcoming features», Axel Rauschmayer
   - «Offline is the new Black», Max Stoiber (Thinkmill)
   - «Rich text editing with Draft.js», Nikolaus Graf
+  - «Веб-приложения: дробим монолит», Грищенко Виктор
 </details>
 
 ### [FrontendConf](http://frontendconf.ru/)
@@ -153,6 +172,12 @@
 ### CodeFest
 
 1 и 2 апреля
+
+## Ростов-на-Дону
+
+### [TК° Conf](http://tkconf.ru/)
+
+8 октября
 
 ## Санкт-Петербург
 

--- a/date.md
+++ b/date.md
@@ -10,6 +10,19 @@
 
 ## Август
 
+### [MoscowJS 33](https://moscowjs.timepad.ru/event/363568/)
+
+25 августа, Москва
+
+<details>
+  <summary>**Доклады**</summary>
+
+  - «I promise — images will be loaded!», Антон Корзунов (Яндекс)
+  - «Viewport», Вопиловский Константин (KamaGames Studio)
+  - «Регрессионное тестирование компонентов верстки», Кондратенко Павел (Rambler&Co)
+  - «Создание WYSIWYG-редакторов для веба», Егор Яковишен (Setka)
+</details>
+
 ### [FrontendFellows #8](https://frontendfellows.timepad.ru/event/357305/)
 
 26 августа, Ижевск
@@ -19,6 +32,7 @@
 
   - «Vue.js», Наталья Коновалова (Центр Высоких Технологий)
   - «Sass colors refactoring», Иван Мартьянов (EPAM Systems)
+  - «Верстальщики не нужны. На самом деле нет», Роман Коробейников (Piano.io)
 </details>
 
 ### [Frontend Union Conf](http://frontend-union.co/)
@@ -52,6 +66,7 @@
   - «Creation of native mobile apps with NativeScript and Angular2», Eugene Alayev
   - «Flux is dead. Long live Flux!», Alexey Raspopov
   - «Reflex and offline-first», Denis Yaremov
+  - «Modern functional concepts and JavaScript», Maks Klymyshyn
 </details>
 
 ### [JS NN #4](https://www.it52.info/events/2016-08-27-js-nn-4)
@@ -121,6 +136,7 @@
   - «React, Relay и GraphQL — вполне себе нормальный компонентный подход», Павел Черторогов
   - «Я и ИоТ», Вадим Макеев (Opera)
   - «Веб-приложения: дробим монолит», Виктор Грищенко
+  - «API Панорам», Кирилл Дмитренко (Яндекс)
 </details>
 
 ### [IT Weekend Ukraine 2016](http://ukraine.itweekend.ua/ua/)
@@ -150,6 +166,10 @@
 
 1 октября, Санкт-Петербург
 
+### [TК° Conf](http://tkconf.ru/)
+
+8 октября, Ростов-на-Дону
+
 ### [Web Standards Days](https://wsd.events/2016/10/29/)
 
 29 октября, Минск
@@ -176,8 +196,10 @@
   <summary>**Доклады**</summary>
 
   - «Build Cross-Platform Desktop Apps with Electron», Feross Aboukhadijeh
+  - «ECMAScript: latest and upcoming features», Axel Rauschmayer
   - «Offline is the new Black», Max Stoiber (Thinkmill)
   - «Rich text editing with Draft.js», Nikolaus Graf
+  - «Веб-приложения: дробим монолит», Грищенко Виктор
 </details>
 
 ## Апрель


### PR DESCRIPTION
Новые митапы:
- [MoscowJS 33](https://moscowjs.timepad.ru/event/363568/), 25 августа, Москва
  - «I promise — images will be loaded!», Антон Корзунов (Яндекс)
  - «Viewport», Вопиловский Константин (KamaGames Studio)
  - «Регрессионное тестирование компонентов верстки», Кондратенко Павел (Rambler&Co)
  - «Создание WYSIWYG-редакторов для веба», Егор Яковишен (Setka)
- [TК° Conf](http://tkconf.ru/), 8 октября, Ростов-на-Дону

Новые доклады:
- [FrontendFellows #8](https://frontendfellows.timepad.ru/event/357305/)
  - «Верстальщики не нужны. На самом деле нет», Роман Коробейников (Piano.io)
- [LvivJS](http://www.lvivjs.org.ua/)
  - «Modern functional concepts and JavaScript», Maks Klymyshyn
- [FrontTalks](http://fronttalks.ru/)
  - «API Панорам», Кирилл Дмитренко (Яндекс)
- [HolyJS](http://holyjs.ru/)
  - «ECMAScript: latest and upcoming features», Axel Rauschmayer
  - «Веб-приложения: дробим монолит», Грищенко Виктор
