### PR TITLE
 FRONTday, 28 сентября, Челябинск; новые доклады

### DIFF
--- a/city.md
+++ b/city.md
@@ -10,6 +10,7 @@
 - **[Санкт-Петербург](#Санкт-Петербург)**
 - [Тольятти](#Тольятти)
 - [Харьков](#Харьков)
+- [Челябинск](#Челябинск)
 
 ## Астана
 
@@ -48,9 +49,9 @@
 <details>
   <summary>**Доклады**</summary>
 
-  - «Advanced SASS», Vadzim Yakushau
-  - «Modular JavaScript: put things on the right place», Andrei Yemelyanchik
   - «Ethereum virtual machines in JS: cryptocurrency revolution», Oleksandr Pastukhov
+  - «Modular JavaScript: put things on the right place», Andrei Yemelyanchik
+  - «Serverless architecture: Functions as a Service», Dzmitry Varabei, Siarhei Melnik
   - «Designers at the lab», Dafna Sharabi
 </details>
 
@@ -80,6 +81,7 @@
   - «Rich text editing with Draft.js», Nikolaus Graf
   - «Sharing files and data with friends using a P2P shared folder powered by Javascript», Mathias Buus Madsen
   - «Веб-приложения: дробим монолит», Грищенко Виктор
+  - «WebVR is the next frontier», Martin Splitt
 </details>
 
 ### [FrontendConf](http://frontendconf.ru/)
@@ -122,8 +124,14 @@
 
   - «&lt;head&gt; — всему голова», Роман Ганин (FBS)
   - «CSS-методологии от О до Б», Алексей Охрименко (IPONWEB)
+  - «PWA. Что это такое?», Сергей Густун
+  - «Вёрстка писем. Развенчиваем мифы», Артур Кох
   - «Я и ИоТ», Вадим Макеев (Opera)
   - «Pokemon GO на веб-технологиях», Егор Коновалов (Центр Высоких Технологий)
+  - «Обманчивая простота HTTP/2», Алексей Уколов
+  - «&lt;iframe&gt; или &lt;script&gt;?», Всеволод Шмыров
+  - «Фронтенд — набор для выживания», Милослав Волосков
+  - «Как зарабатывать миллионы на онлайн-курсах», Александр Першин
 </details>
 
 ## Тольятти
@@ -149,9 +157,26 @@
   <summary>**Доклады**</summary>
 
   - «Выжить с помощью ООП», Максим Гопей
+  - «BDD & Codeception: разделяем и властвуем», Михаил Боднарчук
 </details>
 
 ### [KharkivJS #7](http://kharkivjs.org/)
 
 Ноябрь  
 *Точная дата пока неизвестна*
+
+## Челябинск
+
+### [FRONTday](http://frontday.ru/)
+
+28 сентября
+
+<details>
+  <summary>**Доклады**</summary>
+
+  - «Observable на фронтенде. Как и и почему», Никита Дюмин
+  - «Telegram bot - новый вид интерфейса», Петр Лаптев
+  - «Progressive Web Applications», Анатолий Морозов
+  - «Как я пишу в 2016 на ангуляре и не краснею», Иван Громов
+  - «5 причин, по которым дизайнеры ненавидят фронтенд-разработчиков», Олеся Козлова
+</details>

--- a/date.md
+++ b/date.md
@@ -35,6 +35,20 @@
   - «CSS QuickDraw», Alexander Gerasimov
 </details>
 
+### [FRONTday](http://frontday.ru/)
+
+28 сентября, Челябинск
+
+<details>
+  <summary>**Доклады**</summary>
+
+  - «Observable на фронтенде. Как и и почему», Никита Дюмин
+  - «Telegram bot - новый вид интерфейса», Петр Лаптев
+  - «Progressive Web Applications», Анатолий Морозов
+  - «Как я пишу в 2016 на ангуляре и не краснею», Иван Громов
+  - «5 причин, по которым дизайнеры ненавидят фронтенд-разработчиков», Олеся Козлова
+</details>
+
 ### [The Rolling Scopes #31](https://krakow.rollingscopes.com/)
 
 29 сентября, Краков
@@ -42,9 +56,9 @@
 <details>
   <summary>**Доклады**</summary>
 
-  - «Advanced SASS», Vadzim Yakushau
-  - «Modular JavaScript: put things on the right place», Andrei Yemelyanchik
   - «Ethereum virtual machines in JS: cryptocurrency revolution», Oleksandr Pastukhov
+  - «Modular JavaScript: put things on the right place», Andrei Yemelyanchik
+  - «Serverless architecture: Functions as a Service», Dzmitry Varabei, Siarhei Melnik
   - «Designers at the lab», Dafna Sharabi
 </details>
 
@@ -63,8 +77,14 @@
 
   - «&lt;head&gt; — всему голова», Роман Ганин (FBS)
   - «CSS-методологии от О до Б», Алексей Охрименко (IPONWEB)
+  - «PWA. Что это такое?», Сергей Густун
+  - «Вёрстка писем. Развенчиваем мифы», Артур Кох
   - «Я и ИоТ», Вадим Макеев (Opera)
   - «Pokemon GO на веб-технологиях», Егор Коновалов (Центр Высоких Технологий)
+  - «Обманчивая простота HTTP/2», Алексей Уколов
+  - «&lt;iframe&gt; или &lt;script&gt;?», Всеволод Шмыров
+  - «Фронтенд — набор для выживания», Милослав Волосков
+  - «Как зарабатывать миллионы на онлайн-курсах», Александр Першин
 </details>
 
 ### [AST Frontend meetup #2](https://astfrontend.timepad.ru/event/376009/)
@@ -94,6 +114,7 @@
   <summary>**Доклады**</summary>
 
   - «Выжить с помощью ООП», Максим Гопей
+  - «BDD & Codeception: разделяем и властвуем», Михаил Боднарчук
 </details>
 
 ### [Web Standards Days](https://wsd.events/2016/10/29/)
@@ -127,6 +148,7 @@
   - «Rich text editing with Draft.js», Nikolaus Graf
   - «Sharing files and data with friends using a P2P shared folder powered by Javascript», Mathias Buus Madsen
   - «Веб-приложения: дробим монолит», Грищенко Виктор
+  - «WebVR is the next frontier», Martin Splitt
 </details>
 
 ## Апрель


### PR DESCRIPTION
Новый митап:
- [FRONTday](http://frontday.ru/), 28 сентября, Челябинск
  - «Observable на фронтенде. Как и и почему», Никита Дюмин
  - «Telegram bot - новый вид интерфейса», Петр Лаптев
  - «Progressive Web Applications», Анатолий Морозов
  - «Как я пишу в 2016 на ангуляре и не краснею», Иван Громов
  - «5 причин, по которым дизайнеры ненавидят фронтенд-разработчиков», Олеся Козлова

Новые доклады:
- [The Rolling Scopes #31](https://krakow.rollingscopes.com/)
  - «Serverless architecture: Functions as a Service», Dzmitry Varabei, Siarhei Melnik
- [Web Standards Days](https://wsd.events/2016/10/01/) (1 октября)
  - «PWA. Что это такое?», Сергей Густун
  - «Вёрстка писем. Развенчиваем мифы», Артур Кох
  - «Обманчивая простота HTTP/2», Алексей Уколов
  - «&lt;iframe&gt; или &lt;script&gt;?», Всеволод Шмыров
  - «Фронтенд — набор для выживания», Милослав Волосков
  - «Как зарабатывать миллионы на онлайн-курсах», Александр Першин
- [Съесть собаку](http://eatdog.com.ua/)
  - «BDD & Codeception: разделяем и властвуем», Михаил Боднарчук
- [HolyJS](http://holyjs.ru/)
  - «WebVR is the next frontier», Martin Splitt
