### PR TITLE
Новые митапы и доклады

### DIFF
--- a/city.md
+++ b/city.md
@@ -1,5 +1,6 @@
 # По городам
 
+- **[Астана](#Астана)**
 - [Екатеринбург](#Екатеринбург)
 - **[Киев](#Киев)**
 - **[Минск](#Минск)**
@@ -9,17 +10,32 @@
 - [Ульяновск](#Ульяновск)
 - [Харьков](#Харьков)
 
+## Астана
+
+### [AST Frontend meetup #3](https://astfrontend.timepad.ru/event/432398/)
+
+11 февраля
+
 ## Екатеринбург
 
 ### [DUMP 2017](http://dump-conf.ru/)
 
-14 апреля
+14 апреля, от 4000 руб.
 
 ## Киев
 
 ### [KyivJS](http://kyivjs.org)
 
 21 января
+
+<details>
+  <summary>**Доклады**</summary>
+
+  - «Best practices of Node.js use in production», Никита Галкин
+  - «‘This time I’ll build things the right way’», Алексей Распопов
+  - «Путешествие вглубь Node.js» или как начать писать RPC и случайно ускорить node_redis в 10 раз», Тимур Шемсединов и Алексей Орленко
+  - «Z», Александр Шпак
+</details>
 
 ### [JavaScript Frameworks Day](http://frameworksdays.com/event/js-frameworks-day-2017)
 
@@ -40,14 +56,20 @@
 <details>
   <summary>**Доклады**</summary>
 
+  - «Поговорим о наших младших товарищах», Сергей Попов (Setka)
   - «Играем в браузере», Всеволод Шмыров (Яндекс)
   - «Здесь водятся драконы», Лев Солнцев (МойОфис)
   - «Мой ванильный CSS», Вадим Макеев
   - «JSX? Пфф!», Владимир Гриненко (Яндекс)
+  - «Сбертехнологии фронтенда», Александра Воробьёва (Сбербанк-Технологиях)
   - «CSS-in-JS. Назад в будущее!», Никита Мостовой (HeadHunter)
   - «Веб-компоненты: светлое настоящее», Вадим Черненко (Яндекс)
   - «Brunch — последний сборщик, который вам будет нужен», Алексей Швайка (Hell Yeah)
 </details>
+
+### [Yet another Conference 2017](https://events.yandex.ru/events/yac/30-may-2017/)
+
+30 мая
 
 ### [FrontendConf](http://frontendconf.ru/)
 
@@ -69,6 +91,16 @@
 ### [pitercss conference](https://pitercss.com/)
 
 Июнь
+
+### [HolyJS](https://holyjs-piter.ru)
+
+2 и 3 июня
+
+<details>
+  <summary>**Доклады**</summary>
+
+  - «Build Cross-Platform Desktop Apps with Electron», (Feross Aboukhadijeh)
+</details>
 
 ## Ульяновск
 

--- a/date.md
+++ b/date.md
@@ -3,6 +3,7 @@
 - [Январь](#Январь)
 - [Февраль](#Февраль)
 - [Апрель](#Апрель)
+- [Май](#Май)
 - [Июнь](#Июнь)
 
 ## Январь
@@ -10,6 +11,15 @@
 ### [KyivJS](http://kyivjs.org)
 
 21 января, Киев
+
+<details>
+  <summary>**Доклады**</summary>
+
+  - «Best practices of Node.js use in production», Никита Галкин
+  - «‘This time I’ll build things the right way’», Алексей Распопов
+  - «Путешествие вглубь Node.js» или как начать писать RPC и случайно ускорить node_redis в 10 раз», Тимур Шемсединов и Алексей Орленко
+  - «Z», Александр Шпак
+</details>
 
 ### [pitercss №9](https://pitercss.timepad.ru/event/429617/)
 
@@ -22,16 +32,22 @@
 <details>
   <summary>**Доклады**</summary>
 
+  - «Поговорим о наших младших товарищах», Сергей Попов (Setka)
   - «Играем в браузере», Всеволод Шмыров (Яндекс)
   - «Здесь водятся драконы», Лев Солнцев (МойОфис)
   - «Мой ванильный CSS», Вадим Макеев
   - «JSX? Пфф!», Владимир Гриненко (Яндекс)
+  - «Сбертехнологии фронтенда», Александра Воробьёва (Сбербанк-Технологиях)
   - «CSS-in-JS. Назад в будущее!», Никита Мостовой (HeadHunter)
   - «Веб-компоненты: светлое настоящее», Вадим Черненко (Яндекс)
   - «Brunch — последний сборщик, который вам будет нужен», Алексей Швайка (Hell Yeah)
 </details>
 
 ## Февраль
+
+### [AST Frontend meetup #3](https://astfrontend.timepad.ru/event/432398/)
+
+11 февраля, Астана
 
 ### [RS Conf 2017](https://2017.conf.rollingscopes.com/index.html)
 
@@ -49,7 +65,7 @@
 
 ### [DUMP 2017](http://dump-conf.ru/)
 
-14 апреля, Екатеринбург
+14 апреля, Екатеринбург, от 4000 руб.
 
 ### [Стачка](http://nastachku.ru)
 
@@ -59,7 +75,23 @@
 
 15 апреля, Харьков
 
+## Май
+
+### [Yet another Conference 2017](https://events.yandex.ru/events/yac/30-may-2017/)
+
+30 мая, Москва
+
 ## Июнь
+
+### [HolyJS](https://holyjs-piter.ru)
+
+2 и 3 июня, Санкт-Петербург
+
+<details>
+  <summary>**Доклады**</summary>
+
+  - «Build Cross-Platform Desktop Apps with Electron», (Feross Aboukhadijeh)
+</details>
 
 ### [FrontendConf](http://frontendconf.ru/)
 


### PR DESCRIPTION
Новые митапы:

- [AST Frontend meetup #3](https://astfrontend.timepad.ru/event/432398/), 11 февраля, Астана
- [Yet another Conference 2017](https://events.yandex.ru/events/yac/30-may-2017/), 30 мая, Москва
- [HolyJS](https://holyjs-piter.ru), 2 и 3 июня, Санкт-Петербург
  - «Build Cross-Platform Desktop Apps with Electron», (Feross Aboukhadijeh)

Новые доклады:

- [KyivJS](http://kyivjs.org)
  - «Best practices of Node.js use in production», Никита Галкин
  - «‘This time I’ll build things the right way’», Алексей Распопов
  - «Путешествие вглубь Node.js» или как начать писать RPC и случайно ускорить node_redis в 10 раз», Тимур Шемсединов и Алексей Орленко
  - «Z», Александр Шпак
- [Web Standards Days](https://wsd.events/2017/01/28/)
  - «Поговорим о наших младших товарищах», Сергей Попов (Setka)
  - «Сбертехнологии фронтенда», Александра Воробьёва (Сбербанк-Технологиях)

Билеты на [DUMP](http://dump-conf.ru/section/27/) уже в продаже (от 4000 руб.)