### PR TITLE
Новое событие: moscowcss №2, 6 апреля, Москва

### DIFF
--- a/city.md
+++ b/city.md
@@ -96,6 +96,10 @@
   - «Динамическое создание компонентов в Angular на примере модальных окон», Андрей Яманов (Skyeng)
 </details>
 
+### [moscowcss №2](https://moscowcss.timepad.ru/event/457567/)
+
+6 апреля
+
 ### [FrontendConf](http://frontendconf.ru/)
 
 5 и 6 июня  

--- a/date.md
+++ b/date.md
@@ -100,6 +100,10 @@
 
 Апрель, Киев, от 4000 руб.
 
+### [moscowcss №2](https://moscowcss.timepad.ru/event/457567/)
+
+6 апреля, Москва
+
 ### [Frontend Dev Conf на United Dev Conf](http://unitedconf.com/category/dokladchiki/frontend-dev-conf/)
 
 6-7 апреля, Минск, от 4750 руб.


### PR DESCRIPTION
Новое событие:

- [moscowcss №2](https://moscowcss.timepad.ru/event/457567/), 6 апреля, Москва