### PR TITLE
Новые доклады: moscowcss №2, Москва, 6 апреля

### DIFF
--- a/city.md
+++ b/city.md
@@ -62,6 +62,13 @@
 
 6 апреля
 
+<details>
+  <summary>**Доклады**</summary>
+
+  - «Недокументированные приемы CSS», Дмитрий Григоров (Rambler&Co)
+  - «Пора начинать фыркать – Grid Layout уже здесь», Сергей Попов (Setka)
+</details>
+
 ### [FrontendConf](http://frontendconf.ru/)
 
 5 и 6 июня  

--- a/date.md
+++ b/date.md
@@ -22,6 +22,14 @@
 
 6 апреля, Москва
 
+<details>
+  <summary>**Доклады**</summary>
+
+  - «Недокументированные приемы CSS», Дмитрий Григоров (Rambler&Co)
+  - «Пора начинать фыркать – Grid Layout уже здесь», Сергей Попов (Setka)
+</details>
+
+
 ### [Frontend Dev Conf на United Dev Conf](http://unitedconf.com/category/dokladchiki/frontend-dev-conf/)
 
 6-7 апреля, Минск, от 4750 руб.


### PR DESCRIPTION
Новые доклады: 

- [moscowcss №2](https://moscowcss.timepad.ru/event/457567/)
  - «Недокументированные приемы CSS», Дмитрий Григоров (Rambler&Co)
  - «Пора начинать фыркать – Grid Layout уже здесь», Сергей Попов (Setka)