### PR TITLE
Добавлены доклады fdconf.by, kharkivjs

### DIFF
--- a/city.md
+++ b/city.md
@@ -93,6 +93,10 @@
   - «Создаём виртуальный тур», Игорь Еростенко
   - «Юнит тестирование для ленивых», Владимир Дашукевич
   - «The Compiler & You — Pleasant PureScript», Christoph Hegemann
+  - «Reason: Маргиналы против Хайпа», Илья Климов
+  - «Индустрия разработки софта: что вам нужно знать», Алексей Мигуцкий
+  - «Выборы, выборы, все фреймворки… приторны», Виктор Русакович
+  - «Как правило «победитель получает все» работает и не работает в разработке», Черноокий Александр
 
 </details>
 
@@ -124,7 +128,6 @@
   <summary>Доклады</summary>
   
   - «Effortless Serverless», Aleksandar Simovic
-  - «How to hack a node app», Asim Hussain
   - «Pixel shaders for Web developers», Denis Radin
   - «А что если мы долетим и там будет всё?», Сергей Попов
   - «Async programming with JavaScript and Node.js», Timur Shemsedinov
@@ -136,5 +139,8 @@
   - «Софт скилы», Yuzva Maksim
   - «Тайны зеленого замочка», Vladimir Dashukevich
   - «Vue: business-first», Vitalii Ratyshnyi
+  - «Copy-pASTe», Illya Klymov
+  - «Taking care of performance easiest than ever», Artem Denysov
+  - «UVP and the future of CSSinJS», Oleg Slobodskoi
 
 </details>

--- a/date.md
+++ b/date.md
@@ -47,6 +47,10 @@
   - «Создаём виртуальный тур», Игорь Еростенко
   - «Юнит тестирование для ленивых», Владимир Дашукевич
   - «The Compiler & You — Pleasant PureScript», Christoph Hegemann
+  - «Reason: Маргиналы против Хайпа», Илья Климов
+  - «Индустрия разработки софта: что вам нужно знать», Алексей Мигуцкий
+  - «Выборы, выборы, все фреймворки… приторны», Виктор Русакович
+  - «Как правило «победитель получает все» работает и не работает в разработке», Черноокий Александр
 
 </details>
 
@@ -66,7 +70,7 @@
 
 </details>
 
-### [Web Stansrts Days](https://wsd.events/2017/10/21/)
+### [Web Standarts Days](https://wsd.events/2017/10/21/)
 
 21 октября, Минск
 
@@ -78,7 +82,6 @@
   <summary>Доклады</summary>
   
   - «Effortless Serverless», Aleksandar Simovic
-  - «How to hack a node app», Asim Hussain
   - «Pixel shaders for Web developers», Denis Radin
   - «А что если мы долетим и там будет всё?», Сергей Попов
   - «Async programming with JavaScript and Node.js», Timur Shemsedinov
@@ -90,6 +93,9 @@
   - «Софт скилы», Yuzva Maksim
   - «Тайны зеленого замочка», Vladimir Dashukevich
   - «Vue: business-first», Vitalii Ratyshnyi
+  - «Copy-pASTe», Illya Klymov
+  - «Taking care of performance easiest than ever», Artem Denysov
+  - «UVP and the future of CSSinJS», Oleg Slobodskoi
 
 </details>
 


### PR DESCRIPTION
ДОБАВЛЕНЫ ДОКЛАДЫ

1) [Frontend Dev Conf](https://fdconf.by/ru/), 30 сентября, Минск
- «Reason: Маргиналы против Хайпа», Илья Климов
- «Индустрия разработки софта: что вам нужно знать», Алексей Мигуцкий
- «Выборы, выборы, все фреймворки… приторны», Виктор Русакович
- «Как правило «победитель получает все» работает и не работает в разработке», Черноокий Александр

2) [KharkivJS #8](http://kharkivjs.org/), 28-29 октября, Харьков
- «Copy-pASTe», Illya Klymov
- «Taking care of performance easiest than ever», Artem Denysov
- «UVP and the future of CSSinJS», Oleg Slobodskoi